### PR TITLE
Fix wss formatting

### DIFF
--- a/main/network-details/testnet.md
+++ b/main/network-details/testnet.md
@@ -10,15 +10,15 @@ description: >-
 
 ## Hemi Testnet Details
 
-| Hemi Testnet                  |                                                                                            |
-| ----------------------------- | ------------------------------------------------------------------------------------------ |
-| **Gas Token/Currency Symbol** | ETH                                                                                        |
-| **ChainID**                   | 743111                                                                                     |
-| **RPC API endpoint**          | [https://testnet.rpc.hemi.network/rpc](https://testnet.rpc.hemi.network/rpc)               |
-| **Explorer**                  | [https://testnet.explorer.hemi.xyz](https://testnet.explorer.hemi.xyz)                     |
-| **Tunnel**                    | [https://app.hemi.xyz](https://app.hemi.xyz)                                               |
-| **Faucet**                    | [https://discord.gg/hemixyz](https://discord.gg/hemixyz)                                   |
-| **PoP Miner Endpoint**        | [wss://testnet.rpc.hemi.network/v1/ws/public](wss://testnet.rpc.hemi.network/v1/ws/public) |
+| Hemi Testnet                  |                                                                              |
+| ----------------------------- | -----------------------------------------------------------------------------|
+| **Gas Token/Currency Symbol** | ETH                                                                          |
+| **ChainID**                   | 743111                                                                       |
+| **RPC API endpoint**          | [https://testnet.rpc.hemi.network/rpc](https://testnet.rpc.hemi.network/rpc) |
+| **Explorer**                  | [https://testnet.explorer.hemi.xyz](https://testnet.explorer.hemi.xyz)       |
+| **Tunnel**                    | [https://app.hemi.xyz](https://app.hemi.xyz)                                 |
+| **Faucet**                    | [https://discord.gg/hemixyz](https://discord.gg/hemixyz)                     |
+| **PoP Miner Endpoint**        | wss://testnet.rpc.hemi.network/v1/ws/public                                  |
 
 ***
 


### PR DESCRIPTION
wss is not a clickable link in web browsers so should not be formatted as a url