### PR TITLE
Add hemi hbk address

### DIFF
--- a/building-bitcoin-apps/hemi-bitcoin-kit-hbk/README.md
+++ b/building-bitcoin-apps/hemi-bitcoin-kit-hbk/README.md
@@ -5,6 +5,7 @@
 
 * The Hemi Bitcoin Kit (hBK) is a library of smart contracts for developers to use to build Bitcoin-aware smart contracts.
 * The hBK abstracts away the complications of interacting directly with the hVM Precompiles; parsing query results into data structures that are easy to understand and use.
+* **Latest hBK release on Hemi:** [0x7007dd1C09527B92AEcd8Ae6570B73d09E0B8F12](https://explorer.hemi.xyz/address/0x7007dd1C09527B92AEcd8Ae6570B73d09E0B8F12)
 * **Latest hBK release on Hemi testnet:** [0xeC9fa5daC1118963933e1A675a4EEA0009b7f215](https://testnet.explorer.hemi.xyz/address/0xeC9fa5daC1118963933e1A675a4EEA0009b7f215)
 {% endhint %}
 

--- a/building-bitcoin-apps/hemi-bitcoin-kit-hbk/hbk-smart-contract.md
+++ b/building-bitcoin-apps/hemi-bitcoin-kit-hbk/hbk-smart-contract.md
@@ -5,6 +5,7 @@
 * The Hemi Bitcoin Kit smart contract provides utilities for interacting with Bitcoin data on the Hemi blockchain.&#x20;
 * It includes methods to retrieve Bitcoin address balances, UTXOs, transaction details, and block headers.&#x20;
 * The contract leverages hVM's new precompiles to perform Bitcoin-related queries.
+* **Latest hBK release on Hemi:** [0x7007dd1C09527B92AEcd8Ae6570B73d09E0B8F12](https://explorer.hemi.xyz/address/0x7007dd1C09527B92AEcd8Ae6570B73d09E0B8F12)
 * **Latest hBK release on Hemi testnet:** [0xeC9fa5daC1118963933e1A675a4EEA0009b7f215](https://testnet.explorer.hemi.xyz/address/0xeC9fa5daC1118963933e1A675a4EEA0009b7f215)
 
 ***

--- a/building-bitcoin-apps/introduction.md
+++ b/building-bitcoin-apps/introduction.md
@@ -7,6 +7,7 @@
 * **hVM** is an indexed Bitcoin full node directly accessible inside the EVM.
 * **hBK** is a smart contract library running on Hemi that utilizes hVM and makes Hemi’s Bitcoin awareness easier to use.
 * hVM’s precompile calls and hBK's functions are subject to change in future versions of the Hemi testnet.&#x20;
+* **Latest hBK release on Hemi:** [0x7007dd1C09527B92AEcd8Ae6570B73d09E0B8F12](https://explorer.hemi.xyz/address/0x7007dd1C09527B92AEcd8Ae6570B73d09E0B8F12)
 * **Latest hBK release on Hemi testnet:** [0xeC9fa5daC1118963933e1A675a4EEA0009b7f215](https://testnet.explorer.hemi.xyz/address/0xeC9fa5daC1118963933e1A675a4EEA0009b7f215)
 {% endhint %}
 


### PR DESCRIPTION
The Hemi Bitcoin Kit address was added for Hemi Sepolia, but the link for Hemi was missing.

This PR adds the link to Hemi where the testnet was previously linked